### PR TITLE
Fix the bugs regarding output paths

### DIFF
--- a/xsr
+++ b/xsr
@@ -47,6 +47,11 @@ else {
 	die "Too many arguments.\n";
 }
 
+$outfilename = $outfile;
+$outfilename =~ s/^.*\///;
+$outfilename_noext = $outfilename;
+$outfilename_noext =~ s/\.[^\.]*$//;
+
 if ($imgext == "png") {$mimetype = "image/png"}
 elsif ($imgext == "jpg") {$mimetype = "image/jpeg"}
 else {print usage(); die "Invalid file type $imagext.\n"}
@@ -69,9 +74,6 @@ $scrot = `which scrot`;
 chomp($scrot);
 $scrot or die "scrot unavailable: cannot take screenshots\n";
 
-
-$outfile_saveext = $outfile;
-$outfile_saveext =~ s/\.[^\.]*$//;
 
 sub convertToB64 {
 	if (! -e $_[0]) {
@@ -121,7 +123,7 @@ sub finish {
 		}
 
 		open "ASSOCFILE", "<", "tmpassoconly.html"; # this file contains only image associations, not base64
-		open "FINALFILE", ">", $outfile; # this file will contain base64
+		open "FINALFILE", ">", $outfilename; # this file will contain base64
 		select FINALFILE;
 		while (<ASSOCFILE>) {
 			$_ =~ s/<img src=\"([^\"]+)\" \/>/"<img src=\"data:$mimetype;base64," . convertToB64($1) . "\" \/>"/gie; # replace <img> tags' src attr with a base64 uri
@@ -130,7 +132,7 @@ sub finish {
 		close ASSOCFILE;
 		close FINALFILE;
 		chdir $originaldir;
-		copy "$tmpdir/$outfile", $outfile; # put the output in the original directory
+		copy "$tmpdir/$outfilename", $outfile; # put the output in the original directory
 		remove_tree $tmpdir;
 	}
 	print STDOUT "\n";
@@ -210,7 +212,7 @@ print <<"/html";
 		<style>@font-face{font-family:'Ubuntu';font-style:normal;font-weight:400;src:local('Ubuntu Regular'),local('Ubuntu-Regular'),url(https://fonts.gstatic.com/s/ubuntu/v10/sDGTilo5QRsfWu6Yc11AXg.woff2) format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02C6,U+02DA,U+02DC,U+2000-206F,U+2074,U+20AC,U+2212,U+2215;}body>div.title{font-family:"Ubuntu",sans-serif;font-size:2em;text-align:center;border-bottom-style:solid;border-width:thin;margin-bottom:10px;}div.instruction{margin:10px auto;padding:10px;max-width:80%;border:thin solid lightgray;border-radius:10px;display:table;}div.instruction div.title{font-family:monospace;font-size:1.2em;text-align:center;}div.footer{padding:5px;text-align:center;background-color:#f7f7f7;}img{margin-top:15px;display:block;width:100%}kbd{display:inline-block;margin:0 .1em;padding:.3em .4em;font-family:Ubuntu,Arial,"libra sans",sans-serif;font-size:75%;line-height:inherit;color:#242729;text-shadow:0 1px 0 #FFF;background-color:#e1e3e5;border:1px solid #adb3b9;border-radius:3px;box-shadow:0 1px 0 rgba(12,13,14,0.2),0 0 0 2px #FFF inset;white-space:nowrap;}</style>
 	</head>
 	<body>
-		<div class="title">$outfile_saveext</div>
+		<div class="title">$outfilename_noext</div>
 /html
 
 open "XIN", "-|", "xinput --test-xi2 --root"; # execute xinput with the monitoring options


### PR DESCRIPTION
Any paths that weren't relative didn't work because xsr would try to put them in a directory that didn't exist in /tmp. This resolves that and a related bug where it would put the full path in the HTML document.
(Fixes #27)