### PR TITLE
Redesign READM.md.m4's call

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Options:
 
   -o|--out outfile		Output file name (also can be first argument)
   -e|--edit-images-before-save	Edit images before saving file
+  -d|--image-deps		Do not convert images to base64; instead, output the dependent file and it's resources directory
   -c|--image-extension=ext	Extension of image output (png or jpg)
   -u|--capture-focused		Captured the focused window only
   -q|--quiet			Supress output to STDOUT

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Options:
 
   -o|--out outfile		Output file name (also can be first argument)
   -e|--edit-images-before-save	Edit images before saving file
-  -d|--image-deps		Do not convert images to base64; instead output the dependent file and it's resources directory
   -c|--image-extension=ext	Extension of image output (png or jpg)
   -u|--capture-focused		Captured the focused window only
   -q|--quiet			Supress output to STDOUT

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Make sure you have `scrot` installed; I recommend that you have `imagemagick` an
 # Usage
 
 ```
-Usage: xsr [options] [outfile]
+Usage: ./xsr [options] [outfile]
 
 Options:
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Make sure you have `scrot` installed; I recommend that you have `imagemagick` an
 # Usage
 
 ```
-Usage: ./xsr [options] [outfile]
+Usage: xsr [options] [outfile]
 
 Options:
 

--- a/README.md.m4
+++ b/README.md.m4
@@ -13,7 +13,7 @@ Make sure you have `scrot` installed; I recommend that you have `imagemagick` an
 # Usage
 
 ```
-m4_patsubst(m4_esyscmd([[[./xsr --help | head -n -1]]]), [[[\.\/xsr]]], [[[xsr]]])m4_dnl
+m4_syscmd([[[./xsr --help | head -n -1]]])m4_dnl
 ```
 To quit, press `Break` (usually `Shift`+`Pause`). `Ctrl`+`C` works most of time fine too, although xsr will record that keypress.
 

--- a/README.md.m4
+++ b/README.md.m4
@@ -13,7 +13,7 @@ Make sure you have `scrot` installed; I recommend that you have `imagemagick` an
 # Usage
 
 ```
-m4_syscmd([[[./xsr --help | head -n -1 | sed -s 's#\./xsr#xsr#g']]])m4_dnl
+m4_syscmd([[[./xsr --help | head -n -1 | sed -s 's#\(^Usage:\)\(\s*\)\./\(xsr\)#\1\2\3#']]])m4_dnl
 ```
 To quit, press `Break` (usually `Shift`+`Pause`). `Ctrl`+`C` works most of time fine too, although xsr will record that keypress.
 

--- a/README.md.m4
+++ b/README.md.m4
@@ -13,7 +13,7 @@ Make sure you have `scrot` installed; I recommend that you have `imagemagick` an
 # Usage
 
 ```
-m4_syscmd([[[./xsr --help | head -n -1 | sed -s 's#\(^Usage:\)\(\s*\)\./\(xsr\)#\1\2\3#']]])m4_dnl
+m4_syscmd([[[./xsr --help | head -n -1 | sed -s 's#\(^Usage:\)\(\s*\)\./\(\w\w*\)#\1\2\3#']]])m4_dnl
 ```
 To quit, press `Break` (usually `Shift`+`Pause`). `Ctrl`+`C` works most of time fine too, although xsr will record that keypress.
 

--- a/README.md.m4
+++ b/README.md.m4
@@ -13,7 +13,7 @@ Make sure you have `scrot` installed; I recommend that you have `imagemagick` an
 # Usage
 
 ```
-m4_syscmd([[[./xsr --help | head -n -1]]])m4_dnl
+m4_syscmd([[[./xsr --help | head -n -1 | sed -s 's#\./xsr#xsr#g']]])m4_dnl
 ```
 To quit, press `Break` (usually `Shift`+`Pause`). `Ctrl`+`C` works most of time fine too, although xsr will record that keypress.
 

--- a/README.md.m4
+++ b/README.md.m4
@@ -13,7 +13,7 @@ Make sure you have `scrot` installed; I recommend that you have `imagemagick` an
 # Usage
 
 ```
-m4_syscmd([[[./xsr --help | head -n -1 | sed -s 's#\(^Usage:\)\(\s*\)\./\(\w\w*\)#\1\2\3#']]])m4_dnl
+m4_syscmd([[[./xsr --help | head -n -1 | sed -rs 's#(^Usage:)(\s*)\./(\w+)#\1\2\3#']]])m4_dnl
 ```
 To quit, press `Break` (usually `Shift`+`Pause`). `Ctrl`+`C` works most of time fine too, although xsr will record that keypress.
 

--- a/xsr
+++ b/xsr
@@ -37,7 +37,7 @@ Options:
 
   -o|--out outfile		Output file name (also can be first argument)
   -e|--edit-images-before-save	Edit images before saving file
-  -d|--image-deps		Do not convert images to base64; instead output the dependent file and it's resources directory
+  -d|--image-deps		Do not convert images to base64; instead, output the dependent file and it's resources directory
   -c|--image-extension=ext	Extension of image output (png or jpg)
   -u|--capture-focused		Captured the focused window only
   -q|--quiet			Supress output to STDOUT


### PR DESCRIPTION
Use `sed` rather than `m4_patsubst` to remove the _./_, and let the output flow through
Note that this lets output arbitary content in help message, demo included.

Warning! This doesn't close #72 yet!