### PR TITLE
Added support for ubuntu 22.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,13 @@ The main differences are that this only runs on Linux, that it records your keys
 
 # Installation
 
-See the [Releases Page](https://github.com/nonnymoose/xsr/releases).
-Make sure you have `scrot` installed; I recommend that you have `imagemagick` and `xdotool` installed as well (to add pointer to screenshots).
+Run the **install.sh** script like so:
+```
+sudo sh install.sh
+```
+
+# Dependencies
+Needs gnome-screenshot in order to run properly. It does get installed when running the `install.sh` script
 
 # Usage
 
@@ -30,8 +35,3 @@ Options:
   -h|--help			Print this message
 ```
 To quit, press `Break` (usually `Shift`+`Pause`). `Ctrl`+`C` works most of time fine too, although xsr will record that keypress.
-
-# Notes for this file
-__Please don't edit this file (`README.md`) directly!__
-Please edit rather `README.md.m4`, and run `make README.md` after.
-You can commit the generated changes in `README.md` along with the manual changes in `README.md.m4`.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,4 @@
+# run 'sudo sh install.sh'
+mkdir /usr/share/xsr/
+cp * /usr/share/xsr
+cp xsr /usr/bin/xsr

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,5 @@
 # run 'sudo sh install.sh'
+apt install gnome-screenshot -y
 mkdir /usr/share/xsr/
 cp * /usr/share/xsr
 cp xsr /usr/bin/xsr

--- a/xsr
+++ b/xsr
@@ -119,9 +119,10 @@ if (not $nomouse) {
 	chomp($composite);
 	$composite or warn("composite unavailable: mouse cursor will not appear in screenshots\n");
 }
-my $scrot = `which scrot`;
-chomp($scrot);
-$scrot or die("scrot unavailable: cannot take screenshots\n");
+my $gnome = `which gnome-screenshot`;
+
+chomp($gnome);
+$gnome or die("gnome-screenshot unavailable: cannot take screenshots\n");
 
 
 sub convertToB64 {
@@ -281,7 +282,7 @@ sub takescreenshot {
 		my $curmouseloc = `xdotool getmouselocation`;
 		push(@mousegrabs, $curmouseloc);
 	}
-	system("scrot".( $focusedcap ? " --focused" : "" )." $screeni.$imgext &");
+	system("gnome-screenshot -f $screeni.$imgext &");
 	return $screeni++;
 }
 

--- a/xsr
+++ b/xsr
@@ -282,7 +282,7 @@ sub takescreenshot {
 		my $curmouseloc = `xdotool getmouselocation`;
 		push(@mousegrabs, $curmouseloc);
 	}
-	system("gnome-screenshot -f $screeni.$imgext &");
+	system("gnome-screenshot".( $focusedcap ? " -w" : "" )." -f $screeni.$imgext &");
 	return $screeni++;
 }
 

--- a/xsr
+++ b/xsr
@@ -146,7 +146,7 @@ sub finish {
 		handletypingstate();
 		print $FOUT <<"/html";
 		<div class="footer">
-			<i>Made using <a href="https://github.com/nonnymoose/xsr">X Steps Recorder</a>.</i>
+			<i>Made using <a href="https://github.com/MaximeLaroche/xsr-ubuntu-22.04">X Steps Recorder</a>.</i>
 		</div>
 	</body>
 </html>


### PR DESCRIPTION
`scrot` does not seem wo work properly on ubuntu 22.04

changed th screenshott service to `gonme-screenshot` to add support to ubuntu 22.04